### PR TITLE
Change tumugi version dependency for future release

### DIFF
--- a/tumugi-plugin-command.gemspec
+++ b/tumugi-plugin-command.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "tumugi", "~> 0.5.0"
+  spec.add_runtime_dependency "tumugi", ">= 0.5.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Change dependency from `~> 0.5.0` to `>= 0.5.0`, because plugin can run with future tumugi release, such as `0.6.0`.
