### PR TITLE
Print stderr/stdout after a new line

### DIFF
--- a/lib/tumugi/plugin/task/command.rb
+++ b/lib/tumugi/plugin/task/command.rb
@@ -30,8 +30,8 @@ module Tumugi
           raise Tumugi::TumugiError, e.message
         end
 
-        logger.info out unless out.empty?
-        logger.error err unless err.empty?
+        logger.info  "stdout:\n" + out unless out.empty?
+        logger.error "stderr:\n" + err unless err.empty?
 
         if status.exitstatus == 0
           if output_file && _output


### PR DESCRIPTION
I think this is better.

---

Task

```ruby
task :output_test, type: :command do
  command "mysql -u root -t -e 'select user,host from mysql.user limit 2'"
end
```

Before

```
2017-03-13 01:05:39 +0900 [INFO] (Thread-1: output_test) +-------------+-----------+
| user        | host      |
+-------------+-----------+
| lamanotrama | %         |
| root        | 127.0.0.1 |
+-------------+-----------+
```

After

```
2017-03-13 01:06:39 +0900 [INFO] (Thread-1: output_test) stdout:
+-------------+-----------+
| user        | host      |
+-------------+-----------+
| lamanotrama | %         |
| root        | 127.0.0.1 |
+-------------+-----------+
```