### PR TITLE
Add "quiet" param to suppress logging stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ end
 ```rb
 task :task1, type: :command do
   command "echo 'success'"
+  ## If you don't want to output stdout as log, set "quiet" param
+  # quiet true
   output_file "result.txt"
 end
 ```

--- a/lib/tumugi/plugin/task/command.rb
+++ b/lib/tumugi/plugin/task/command.rb
@@ -13,6 +13,7 @@ module Tumugi
       param :command, type: :string, required: true
       param :output_file, type: :string
       param :env, type: :hash, default: {}
+      param :quiet, type: :hash, default: false
 
       def output
         unless output_file.nil?
@@ -30,7 +31,7 @@ module Tumugi
           raise Tumugi::TumugiError, e.message
         end
 
-        logger.info out unless out.empty?
+        logger.info out unless out.empty? or quiet
         logger.error err unless err.empty?
 
         if status.exitstatus == 0

--- a/lib/tumugi/plugin/task/command.rb
+++ b/lib/tumugi/plugin/task/command.rb
@@ -13,7 +13,7 @@ module Tumugi
       param :command, type: :string, required: true
       param :output_file, type: :string
       param :env, type: :hash, default: {}
-      param :quiet, type: :hash, default: false
+      param :quiet, type: :bool, default: false
 
       def output
         unless output_file.nil?


### PR DESCRIPTION
When using with `output_file` param, sometimes we do not want to output the same contents to log. Especially when it is so large.